### PR TITLE
✨ New Feature: UnivCert email verification feature

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,8 @@
 // src/app.js
 const express = require("express");
+const cors = require("cors");
+const morgan = require("morgan");
+
 const adminRoutes = require("./routes/adminRoutes");
 const authRoutes = require("./routes/authRoutes");
 const devRoutes = require("./routes/devRoutes");
@@ -7,16 +10,18 @@ const univCertRoutes = require("./routes/univCertRoutes");
 const userRoutes = require("./routes/userRoutes"); // ← 새로 추가
 
 const app = express();
+app.use(cors());
 app.use(express.json());
+app.use(morgan("dev"));
 
 // 이미 등록된 라우트
-app.use("/admin", adminRoutes);
-app.use("/auth", authRoutes);
-app.use("/dev", devRoutes);
-app.use("/univcert", univCertRoutes);
+app.use("/api/admin", adminRoutes);
+app.use("/api/auth", authRoutes);
+app.use("/api/dev", devRoutes);
+app.use("/api/univcert", univCertRoutes);
 
 // ✅ 새로 추가: /user
-app.use("/user", userRoutes);
+app.use("/api/user", userRoutes);
 
 // 기본 라우트
 app.get("/", (req, res) => {

--- a/src/controllers/univCertController.js
+++ b/src/controllers/univCertController.js
@@ -1,6 +1,5 @@
 require("dotenv").config();
 const axios = require("axios");
-const univCertService = require("../services/univCertService");
 
 // ✅ 이메일 도메인 기반으로 대학명 자동 설정
 const universityDomains = {

--- a/src/controllers/univCertController.js
+++ b/src/controllers/univCertController.js
@@ -1,25 +1,84 @@
+require("dotenv").config();
+const axios = require("axios");
 const univCertService = require("../services/univCertService");
 
-// 이메일 인증 코드 전송
-exports.sendVerificationCode = async (req, res) => {
-  try {
-    console.log("📩 요청된 이메일:", req.body); // 🚨 요청 데이터 확인
+// ✅ 이메일 도메인 기반으로 대학명 자동 설정
+const universityDomains = {
+  "korea.ac.kr": "고려대학교",
+  "g.hongik.ac.kr": "홍익대학교",
+};
 
-    const { email } = req.body;
-    const response = await univCertService.sendVerificationCode(email);
-    res.status(200).json(response);
+exports.sendOtp = async (req, res) => {
+  console.log("📩 [DEBUG] sendOtp controller called with body:", req.body);
+
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ message: "이메일을 입력해주세요." });
+  }
+
+  // 📌 이메일 도메인 확인 후 대학명 설정
+  const emailDomain = email.split("@")[1];
+  const univName = universityDomains[emailDomain];
+
+  if (!univName) {
+    return res.status(400).json({ message: "지원되지 않는 학교 이메일입니다." });
+  }
+
+  try {
+    // ✅ UnivCert API 호출
+    const response = await axios.post("https://univcert.com/api/v1/certify", {
+      key: process.env.UNIVCERT_API_KEY,
+      email: email,
+      univName: univName, // ✅ 대학명 자동 설정
+      univ_check: true, // ✅ true = 해당 대학 재학 여부 체크
+    });
+
+    // ✅ UnivCert 응답 확인
+    if (response.data.success) {
+      console.log(`📨 [DEBUG] UnivCert OTP Sent to ${email}`);
+      return res.status(200).json({ message: "OTP 전송 완료" });
+    } else {
+      console.error("❌ [ERROR] UnivCert OTP Failed:", response.data);
+      return res.status(400).json({ message: "OTP 전송 실패", error: response.data });
+    }
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    console.error("❌ [ERROR] UnivCert API 요청 실패:", error);
+    return res.status(500).json({ message: "서버 오류 발생", error: error.response?.data || error.message });
   }
 };
 
-// 인증 코드 검증
-exports.verifyCode = async (req, res) => {
+
+exports.verifyOtp = async (req, res) => {
+  console.log("📩 [DEBUG] verifyOtp controller called with body:", req.body);
+
+  const { email, code } = req.body;
+  if (!email || !code) {
+    return res.status(400).json({ message: "이메일과 인증코드를 입력해주세요." });
+  }
+
   try {
-    const { email, code } = req.body; // ✅ code 추가
-    const response = await univCertService.verifyCode(email, code); // ✅ code 전달
-    res.status(200).json(response);
+    // ✅ UnivCert 인증 코드 확인 요청
+    const response = await axios.post("https://univcert.com/api/v1/certifycode", {
+      key: process.env.UNIVCERT_API_KEY,
+      email: email,
+      univName: "홍익대학교",
+      code: code,
+    });
+
+    if (response.data.success) {
+      console.log(`✅ [DEBUG] UnivCert 인증 성공: ${email}`);
+      return res.status(200).json({
+        message: "인증 성공",
+        univName: response.data.univName,
+        certified_email: response.data.certified_email,
+        certified_date: response.data.certified_date,
+      });
+    } else {
+      console.error("❌ [ERROR] UnivCert 인증 실패:", response.data);
+      return res.status(400).json({ message: "인증 실패", error: response.data });
+    }
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    console.error("❌ [ERROR] UnivCert 인증 요청 실패:", error);
+    return res.status(500).json({ message: "서버 오류 발생", error: error.response?.data || error.message });
   }
 };

--- a/src/routes/univCertRoutes.js
+++ b/src/routes/univCertRoutes.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 const univCertController = require("../controllers/univCertController");
 
-router.post("/send-otp", univCertController.sendVerificationCode);
-router.post("/verify-otp", univCertController.verifyCode); // ✅ verifyCode 라우트 추가
+router.post("/send-otp", univCertController.sendOtp);
+router.post("/verify-otp", univCertController.verifyOtp); // ✅ verifyCode 라우트 추가
 
 module.exports = router;


### PR DESCRIPTION
# 🚀 Refactor UnivCert Email Verification & Add Dev Email Clear API

---

## 📝 PR 설명
이번 PR에서는 다음과 같은 주요 변경 사항이 포함되었습니다.

### 1️⃣ UnivCert 이메일 인증 리팩토링
- 이메일 도메인 기반으로 대학명을 자동 설정하도록 수정 (`univCertController.js`)
- `sendOtp`, `verifyOtp` 컨트롤러에서 `univCertService.js`를 활용하여 UnivCert API 요청을 처리하도록 변경
- API 응답 처리 로직 개선 및 디버깅 로그 추가

### 2️⃣ API 경로 통일 (`app.js` 수정)
- 기존 `/auth`, `/dev`, `/univcert` 등의 라우트를 `/api` 하위로 이동하여 일관성 유지  
  (예: `/auth → /api/auth`, `/dev → /api/dev`, `/univcert → /api/univcert`)

### 3️⃣ 인증된 이메일 전체 삭제 기능 추가 (`devController.js`, `devRoutes.js`)
- `DELETE /api/dev/clear-verified-emails` 엔드포인트 추가
- `VerifiedEmail` 테이블의 모든 데이터를 삭제하는 기능 구현
- 개발 환경에서 테스트를 용이하게 하기 위한 기능

---

## 🔍 주요 변경 파일

파일 | 변경 내용
-- | --
`src/app.js` | API 경로 통일 (`/api` prefix 추가)
`src/controllers/univCertController.js` | UnivCert API 리팩토링, 대학 자동 매핑 추가
`src/services/univCertService.js` | UnivCert API 호출 기능 모듈화
`src/routes/univCertRoutes.js` | 컨트롤러 함수명 변경 (`sendOtp`, `verifyOtp`)
`src/controllers/devController.js` | `clearVerifiedEmails` API 추가
`src/routes/devRoutes.js` | `DELETE /api/dev/clear-verified-emails` 라우트 추가

---

## ✅ 테스트 방법

### 1️⃣ UnivCert 이메일 인증 테스트

#### 🔹 OTP 전송 (홍익대, 고려대 이메일 지원)
```bash
curl -X POST http://localhost:3000/api/univcert/send-otp \
     -H "Content-Type: application/json" \
     -d '{"email": "test@g.hongik.ac.kr"}'
```

#### 🔹 OTP 인증
```bash
curl -X POST http://localhost:3000/api/univcert/verify-otp \
     -H "Content-Type: application/json" \
     -d '{"email": "test@g.hongik.ac.kr", "code": 123456}'
```

### 2️⃣ 인증된 이메일 전체 삭제 테스트
```bash
curl -X DELETE http://localhost:3000/api/dev/clear-verified-emails
```

## ✅ 기대 결과: "✅ 모든 인증된 이메일이 삭제되었습니다." 응답 확인

### 🚀 병합 후 작업

- [ ] dev 브랜치로 병합 후, 관련된 기능에 대한 추가 테스트 진행
- [ ] feature/univcert-verification 및 feature/dev-clear-emails 브랜치 삭제